### PR TITLE
Fix for connection error when the device is unavailable

### DIFF
--- a/NokeMobileLibrary/Classes/NokeDeviceManager.swift
+++ b/NokeMobileLibrary/Classes/NokeDeviceManager.swift
@@ -167,6 +167,12 @@ public class NokeDeviceManager: NSObject, CBCentralManagerDelegate, NokeDeviceDe
     /// typealias used for handling bytes from the lock
     public typealias byteArray = UnsafeMutablePointer<UInt8>
     
+    /// property used to detect if a connection fails when a device that is not available tries to create a connection
+    public var connectionTimer: Timer?
+    
+    /// number of seconds the connection process will wait until return an error connection
+    public let numberOfSecondsToDetectTheConnectionError: Double = 2
+    
     /**
      Initializes a new NokeDeviceManager
      - Returns: NokeDeviceManager
@@ -218,6 +224,8 @@ public class NokeDeviceManager: NSObject, CBCentralManagerDelegate, NokeDeviceDe
         self.insertNokeDevice(noke)
         let connectionOptions : [String: AnyObject] = [CBConnectPeripheralOptionNotifyOnDisconnectionKey: NSNumber.init(value: true as Bool)]
         if (noke.peripheral != nil){
+            invalidateConnectionTimer()
+            initializeConnectionTimer()
             cm.connect(noke.peripheral!, options: connectionOptions)
         }
     }
@@ -229,6 +237,7 @@ public class NokeDeviceManager: NSObject, CBCentralManagerDelegate, NokeDeviceDe
      */
     public func disconnectNokeDevice(_ noke:NokeDevice){
         if((noke.peripheral) != nil){
+            invalidateConnectionTimer()
             cm.cancelPeripheralConnection(noke.peripheral!)
         }
     }
@@ -344,6 +353,7 @@ public class NokeDeviceManager: NSObject, CBCentralManagerDelegate, NokeDeviceDe
     }
     
     public func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        invalidateConnectionTimer()
         let noke = self.nokeWithPeripheral(peripheral)
         if(noke == nil){
             return
@@ -359,6 +369,7 @@ public class NokeDeviceManager: NSObject, CBCentralManagerDelegate, NokeDeviceDe
     }
     
     public func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+        invalidateConnectionTimer()
         let noke = self.nokeWithPeripheral(peripheral)
         if(noke == nil){
             return
@@ -695,6 +706,19 @@ public class NokeDeviceManager: NSObject, CBCentralManagerDelegate, NokeDeviceDe
         }
     }
     
+    /// Initializes the connection timer property
+    public func initializeConnectionTimer() {
+         connectionTimer = Timer.scheduledTimer(timeInterval: numberOfSecondsToDetectTheConnectionError, target: self, selector: #selector(connectionTimeWasReached), userInfo: nil, repeats: false)
+     }
     
-    
+    /// Invalidates the connection timer property
+     public func invalidateConnectionTimer() {
+         connectionTimer?.invalidate()
+         connectionTimer = nil
+     }
+     
+    /// Once the connection time is reached it sends the delegate error
+     @objc public func connectionTimeWasReached() {
+         self.delegate?.nokeErrorDidOccur(error: NokeDeviceManagerError.nokeDeviceShutdownResult, message: "Connection error", noke: nil)
+     }
 }


### PR DESCRIPTION
The current issue is the following:
The users tries to connect with a device, once the user presses the connect button the device was in range, but when the connect method is called in the DeviceManager in that point the device is unavailable. For this reason the code is not returning an answer.
This is a corner case but is important to have cover it to avoid unexpected behaviors when one app implements this SDK.

The solution was implement a timer in the connection method to know if the connection was success or not, if for some reason one of the delegates relates with the connection are not calling, the timer will trigger an error and report this error to the other layers.

Also is important to cancel the pending connection because once the device is available again the device will make the connection automatically this could cause some security issues because the user couldn't be in front of the lock
 